### PR TITLE
Fix read csv file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -122,7 +122,6 @@ void read_csv_file(const char *file_path, void ***all_data, size_t *data_size)
             // add data_in_row to all_data
             arrput(*all_data, data_in_row);
             arrfree(char_in_row);
-            arrfree(data_in_row);
             char_in_row = NULL;
             data_in_row = NULL;
             // check if EOF


### PR DESCRIPTION
removed freeing of  the `data_in_row`-array
because it contains the read data of float values of the row.

In every run in the `while`, one row of float values is read. 
After the row is read into this dynamic array,  it stored just as a pointer in `all_data` array.
So if it is freed via `arrfree(data_in_row);` the `all_data` just consists pointer to non-existent row arrays.


